### PR TITLE
Post-installation Script for Ubuntu 24.04 LTS

### DIFF
--- a/ratt-software/README.md
+++ b/ratt-software/README.md
@@ -1,0 +1,247 @@
+# Research Group Post-Install Script
+
+A robust, safe, and interactive post-installation script for Ubuntu 24.04 LTS designed for research groups. This script helps set up essential software packages with proper state tracking, rollback capabilities, and comprehensive logging.
+
+## Features
+
+### ✅ Core Capabilities
+- **Pure Python**: No external dependencies required
+- **Idempotent**: Safe to run multiple times
+- **State Tracking**: Maintains installation history in JSON format
+- **Rollback Support**: Can undo previous installations
+- **Dry Run Mode**: Preview changes without executing
+- **Interactive Mode**: User-guided software selection
+- **Comprehensive Logging**: Detailed logs with configurable verbosity
+- **Category-based Installation**: Organized software packages by purpose
+
+### 🛡️ Safety Features
+- **Error Handling**: Graceful failure recovery
+- **Command Validation**: Checks for command availability before execution
+- **Installation Tracking**: Records success/failure of each package
+- **Rollback Capability**: Undo installations if needed
+- **Dry Run Testing**: Preview all actions before execution
+
+## Software Categories
+
+### Essential (`essential`)
+- **curl**: Data transfer tool
+- **wget**: Web downloader  
+- **git**: Version control system
+- **vim**: Text editor
+- **htop**: System monitor
+- **tree**: Directory tree viewer
+- **zip/unzip**: Archive utilities
+
+### Development (`development`)
+- **build-essential**: Compilation tools
+- **cmake**: Build system
+- **nodejs/npm**: Node.js runtime
+- **docker**: Container platform
+- **code**: VS Code editor (via snap)
+
+### Python (`python`)
+- **python3-dev**: Python development headers
+- **python3-pip**: Python package installer
+- **uv**: Fast Python package manager (custom install)
+- **poetry**: Python dependency management (custom install)
+- **pipx**: Install Python apps in isolation
+
+### Research (`research`)
+- **r-base**: R statistical computing
+- **texlive**: LaTeX document system
+- **pandoc**: Document converter
+
+### Multimedia (`multimedia`)
+- **ffmpeg**: Multimedia framework
+- **imagemagick**: Image manipulation
+- **vlc**: Media player (via snap)
+
+### Productivity (`productivity`)
+- **firefox**: Web browser (via snap)
+- **libreoffice**: Office suite (via snap)
+- **thunderbird**: Email client (via snap)
+
+## Usage Examples
+
+### Basic Installation
+```bash
+# Install essential software only (default)
+python3 post-install.py
+
+# Install specific categories
+python3 post-install.py --categories essential development python
+
+# Install everything except multimedia
+python3 post-install.py --categories essential development python research productivity
+```
+
+### Interactive Mode
+```bash
+# Let users choose what to install
+python3 post-install.py --interactive --categories essential development
+```
+
+### Testing and Debugging
+```bash
+# Preview what would be installed
+python3 post-install.py --dry-run --verbose
+
+# Check what categories are available
+python3 post-install.py --help
+```
+
+### Safety and Rollback
+```bash
+# Exclude specific software
+python3 post-install.py --exclude docker nodejs
+
+# Rollback last installation session
+python3 post-install.py --rollback
+
+# Skip system upgrades
+python3 post-install.py --no-upgrade
+```
+
+### Custom Logging
+```bash
+# Custom log location
+python3 post-install.py --log-file /tmp/install.log --state-file /tmp/state.json
+```
+
+## Command Line Options
+
+| Option | Description |
+|--------|-------------|
+| `-h, --help` | Show help message |
+| `-v, --verbose` | Enable verbose logging |
+| `-d, --dry-run` | Preview commands without executing |
+| `-i, --interactive` | Interactive software selection |
+| `--rollback` | Rollback previous installation |
+| `--no-upgrade` | Skip apt upgrade step |
+| `--categories` | Specify categories to install |
+| `--exclude` | Exclude specific software |
+| `--log-file` | Custom log file path |
+| `--state-file` | Custom state file path |
+
+## File Structure
+
+```
+post-install.py          # Main script
+post-install.log         # Execution log (created automatically)
+post-install-state.json  # Installation state tracking (created automatically)
+README.md               # This documentation
+```
+
+## State Management
+
+The script maintains a JSON state file (`post-install-state.json`) that tracks:
+- Installation attempts with timestamps
+- Success/failure status
+- Package lists for each software
+- Installation methods used
+- Software categories
+
+This enables:
+- **Idempotent operations**: Skip already installed software
+- **Rollback functionality**: Undo recent installations
+- **Installation history**: Track what was installed when
+- **Resume capability**: Continue after interruptions
+
+## Extending the Script
+
+### Adding New Software
+
+1. **Choose appropriate category** or create a new one in `SoftwareCategory`
+2. **Add to SOFTWARE_CATALOG** with this structure:
+```python
+"software-name": {
+    "packages": ["package1", "package2"],  # Empty for custom installs
+    "method": "apt|snap|custom",           # Installation method
+    "description": "Brief description"      # User-friendly description
+}
+```
+
+3. **For custom installations**: Add function to `install_custom_software()`
+
+### Adding Research Group Specific Software
+
+To customize for your research group, consider:
+
+1. **Create new categories** (e.g., `BIOINFORMATICS`, `MACHINE_LEARNING`)
+2. **Add domain-specific tools**:
+   - Computational biology tools
+   - Statistical software
+   - Specialized libraries
+   - Group-specific configurations
+
+3. **Custom installation methods** for:
+   - Conda environments
+   - Docker containers
+   - Custom compiled software
+   - License-managed software
+
+## Best Practices
+
+### For System Administrators
+- **Test with `--dry-run`** before actual deployment
+- **Use state files** to track lab-wide installations
+- **Customize categories** for your research domain
+- **Set up logging** in a centralized location
+
+### For Users
+- **Start with essential** category for basic setup
+- **Use interactive mode** when unsure about software needs
+- **Keep state files** for rollback capability
+- **Review logs** if installations fail
+
+### For Developers
+- **Add error handling** for new installation methods
+- **Test rollback functionality** for new software
+- **Update documentation** when adding features
+- **Maintain category organization** for clarity
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Permission errors**: Run with `sudo` for system packages
+2. **Network issues**: Check internet connectivity for downloads
+3. **Package conflicts**: Use `--exclude` to skip problematic packages
+4. **Partial installations**: Use `--rollback` to clean up
+
+### Recovery Steps
+
+1. **Check logs** in `post-install.log` for detailed error information
+2. **Use rollback** if installation partially succeeded
+3. **Verify system state** with `--dry-run` mode
+4. **Exclude problematic packages** and retry
+
+### Getting Help
+
+1. **Run with `--help`** for usage information
+2. **Check verbose logs** with `-v` flag
+3. **Test with dry run** to understand behavior
+4. **Review state file** for installation history
+
+## Security Considerations
+
+- **Script verification**: Review script contents before execution
+- **Network downloads**: Custom installers download from official sources
+- **Package verification**: Uses system package managers with verification
+- **State file protection**: Contains installation history (not sensitive)
+- **Log file security**: May contain system information
+
+## Contributing
+
+When extending this script:
+
+1. **Maintain backwards compatibility**
+2. **Add comprehensive error handling**
+3. **Update documentation**
+4. **Test rollback functionality**
+5. **Follow existing code patterns**
+6. **Consider cross-platform compatibility**
+
+## License
+
+This script is designed for research group use. Modify and distribute according to your institution's policies.

--- a/ratt-software/ubuntu-24.04-lts-post-install.py
+++ b/ratt-software/ubuntu-24.04-lts-post-install.py
@@ -1,0 +1,763 @@
+import logging
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+import json
+from time import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+# Globals
+FOUND_COMMANDS = set()
+LOG_PATH: Path
+LOGGER: logging.Logger
+STATE_FILE: Path
+INSTALLATION_STATE: dict
+
+# Flags
+VERBOSE: bool = False
+UPGRADE: bool = True
+DRY_RUN: bool = False
+INTERACTIVE: bool = False
+ROLLBACK: bool = False
+
+
+class SoftwareCategory(Enum):
+    """Categories of software that can be installed"""
+
+    ESSENTIAL = "essential"  # Basic system tools
+    DEVELOPMENT = "development"  # Programming tools
+    PYTHON = "python"  # Python ecosystem
+    RESEARCH = "research"  # Research-specific tools
+    MULTIMEDIA = "multimedia"  # Audio/video tools
+    PRODUCTIVITY = "productivity"  # General productivity tools
+
+
+@dataclass
+class InstallationRecord:
+    """Record of an installation attempt"""
+
+    name: str
+    category: SoftwareCategory
+    method: str  # apt, snap, curl, etc.
+    success: bool
+    timestamp: float
+    packages: list  # actual packages installed
+
+
+# Software catalog - easy to extend for your research group
+SOFTWARE_CATALOG = {
+    SoftwareCategory.ESSENTIAL: {
+        "curl": {
+            "packages": ["curl"],
+            "method": "apt",
+            "description": "Data transfer tool",
+        },
+        "wget": {
+            "packages": ["wget"],
+            "method": "apt",
+            "description": "Web downloader",
+        },
+        "git": {
+            "packages": ["git"],
+            "method": "apt",
+            "description": "Version control system",
+        },
+        "vim": {"packages": ["vim"], "method": "apt", "description": "Text editor"},
+        "htop": {
+            "packages": ["htop"],
+            "method": "apt",
+            "description": "System monitor",
+        },
+        "tree": {
+            "packages": ["tree"],
+            "method": "apt",
+            "description": "Directory tree viewer",
+        },
+        "zip": {
+            "packages": ["zip", "unzip"],
+            "method": "apt",
+            "description": "Archive utilities",
+        },
+    },
+    SoftwareCategory.DEVELOPMENT: {
+        "build-essential": {
+            "packages": ["build-essential"],
+            "method": "apt",
+            "description": "Compilation tools",
+        },
+        "cmake": {
+            "packages": ["cmake"],
+            "method": "apt",
+            "description": "Build system",
+        },
+        "nodejs": {
+            "packages": ["nodejs", "npm"],
+            "method": "apt",
+            "description": "Node.js runtime",
+        },
+        "docker": {
+            "packages": ["docker.io"],
+            "method": "apt",
+            "description": "Container platform",
+        },
+        "code": {
+            "packages": ["code"],
+            "method": "snap",
+            "description": "VS Code editor",
+        },
+    },
+    SoftwareCategory.PYTHON: {
+        "python3-dev": {
+            "packages": ["python3-dev", "python3-pip"],
+            "method": "apt",
+            "description": "Python development",
+        },
+        "uv": {
+            "packages": [],
+            "method": "custom",
+            "description": "Fast Python package manager",
+        },
+        "poetry": {
+            "packages": [],
+            "method": "custom",
+            "description": "Python dependency management",
+        },
+        "pipx": {
+            "packages": ["pipx"],
+            "method": "apt",
+            "description": "Install Python apps in isolation",
+        },
+    },
+    SoftwareCategory.RESEARCH: {
+        "r-base": {
+            "packages": ["r-base"],
+            "method": "apt",
+            "description": "R statistical computing",
+        },
+        "texlive": {
+            "packages": ["texlive-latex-base"],
+            "method": "apt",
+            "description": "LaTeX document system",
+        },
+        "pandoc": {
+            "packages": ["pandoc"],
+            "method": "apt",
+            "description": "Document converter",
+        },
+    },
+    SoftwareCategory.MULTIMEDIA: {
+        "ffmpeg": {
+            "packages": ["ffmpeg"],
+            "method": "apt",
+            "description": "Multimedia framework",
+        },
+        "imagemagick": {
+            "packages": ["imagemagick"],
+            "method": "apt",
+            "description": "Image manipulation",
+        },
+        "vlc": {"packages": ["vlc"], "method": "snap", "description": "Media player"},
+    },
+    SoftwareCategory.PRODUCTIVITY: {
+        "firefox": {
+            "packages": ["firefox"],
+            "method": "snap",
+            "description": "Web browser",
+        },
+        "libreoffice": {
+            "packages": ["libreoffice"],
+            "method": "snap",
+            "description": "Office suite",
+        },
+        "thunderbird": {
+            "packages": ["thunderbird"],
+            "method": "snap",
+            "description": "Email client",
+        },
+    },
+}
+
+
+def parse_arguments():
+    global VERBOSE, UPGRADE, DRY_RUN, LOG_PATH, INTERACTIVE, ROLLBACK, STATE_FILE
+    parser = argparse.ArgumentParser(
+        description="Post-installation script for setting up research group software",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s                                    # Install essential software only
+  %(prog)s --categories essential development # Install specific categories
+  %(prog)s --interactive                      # Interactive selection
+  %(prog)s --dry-run --verbose               # Preview what would be installed
+  %(prog)s --rollback                        # Rollback last installation
+        """,
+    )
+    parser.add_argument(
+        "-m", "--minimal", action="store_true", help="Minimal installation used (Cannot run with -f)."
+    )
+    parser.add_argument(
+        "-f", "--full", action="store_true", help="Full installation used (Cannot run with -m)."
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose logging"
+    )
+    parser.add_argument(
+        "--no-upgrade", action="store_true", help="Skip apt upgrade step"
+    )
+    parser.add_argument(
+        "-d",
+        "--dry-run",
+        action="store_true",
+        help="Preview commands without executing",
+    )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Interactive software selection",
+    )
+    parser.add_argument(
+        "--rollback", action="store_true", help="Rollback previous installation"
+    )
+    parser.add_argument(
+        "--categories",
+        nargs="+",
+        choices=[cat.value for cat in SoftwareCategory],
+        default=["essential"],
+        help="Software categories to install (default: essential)",
+    )
+    parser.add_argument(
+        "--exclude",
+        nargs="+",
+        default=[],
+        help="Software names to exclude from installation",
+    )
+    parser.add_argument(
+        "--log-file",
+        default="post-install.log",
+        help="Specify log file path (default: post-install.log)",
+    )
+    parser.add_argument(
+        "--state-file",
+        default="post-install-state.json",
+        help="State file for tracking installations (default: post-install-state.json)",
+    )
+
+    args = parser.parse_args()
+    VERBOSE = args.verbose
+    UPGRADE = not args.no_upgrade
+    DRY_RUN = args.dry_run
+    INTERACTIVE = args.interactive
+    ROLLBACK = args.rollback
+    LOG_PATH = Path(args.log_file)
+    STATE_FILE = Path(args.state_file)
+
+
+def setup_logging():
+    """Configure logging based on verbose flag"""
+    global LOGGER
+    level = logging.DEBUG if VERBOSE else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(levelname)-5s - %(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+            logging.FileHandler(LOG_PATH),
+        ],
+    )
+    LOGGER = logging.getLogger(__name__)
+
+
+def safely_shutdown():
+    LOGGER.info("Safely shutting down")
+    sys.exit(1)
+
+
+def cmd_exists(cmd: str) -> bool:
+    if cmd in FOUND_COMMANDS:
+        LOGGER.debug("Executable found. Previously checked")
+        return True
+    LOGGER.debug(f"Checking if new command {cmd} installed")
+    if DRY_RUN and cmd not in FOUND_COMMANDS:
+        FOUND_COMMANDS.add(cmd)
+        LOGGER.debug("Executable found. Adding to checked (DRY RUN)")
+        return True
+    try:
+        result = subprocess.run(
+            ["which", cmd], check=True, capture_output=True, text=True
+        )
+        if result.returncode == 0:
+            FOUND_COMMANDS.add(cmd)
+            LOGGER.debug("Executable found. Adding to checked")
+            return True
+    except Exception:
+        pass
+    LOGGER.debug("Executable not found")
+    return False
+
+
+def run_command(*cmd: str) -> int:
+    if not cmd_exists(cmd[0]):
+        LOGGER.debug(f"Command {cmd[0]} not found. Consider installing")
+        return -1
+    LOGGER.debug(f"Running: {' '.join(cmd)}")
+    if DRY_RUN:
+        FOUND_COMMANDS.add(cmd)
+        LOGGER.debug(f"Completed [DRY-RUN]: {cmd[0]}")
+        return 0
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        LOGGER.debug(f"Completed [{result.returncode}]: {cmd[0]}")
+        return result.returncode
+    except subprocess.CalledProcessError as error:
+        LOGGER.error(f"Failed: {' '.join(cmd)}")
+        LOGGER.error(f"Error: {error}")
+        safely_shutdown()
+    return 0
+
+
+def apt_update() -> int:
+    ret = run_command("apt", "update", "-y")
+    if ret == -1:
+        LOGGER.error("Missing apt command")
+        return 1
+    elif ret != 0:
+        LOGGER.error("Failed to update apt package list")
+        return 1
+    else:
+        LOGGER.debug("Update completed")
+        return 0
+
+
+def apt_upgrade() -> int:
+    LOGGER.debug("Upgrading apt packages")
+    ret = run_command("apt", "upgrade", "-y")
+    if ret == -1:
+        LOGGER.error("Missing apt command")
+        return 1
+    elif ret != 0:
+        LOGGER.error("Failed to upgrade apt packages")
+        return 1
+    else:
+        LOGGER.debug("Upgrade completed")
+        return 0
+
+
+def apt_install(*progs: str) -> int:
+    if len(progs) == 0:
+        LOGGER.error("No programs provided to install")
+        return 1
+    LOGGER.debug(f"Installing via apt: {', '.join(progs)}")
+    ret = run_command("apt", "install", "-y", *progs)
+    if ret == -1:
+        LOGGER.error("Missing apt command")
+        return 1
+    elif ret != 0:
+        LOGGER.error("Failed to install programs")
+        return 1
+    else:
+        LOGGER.debug("Installation completed")
+        return 0
+
+
+def load_installation_state() -> dict:
+    """Load previous installation state from file"""
+    global INSTALLATION_STATE
+    if STATE_FILE.exists():
+        try:
+            with open(STATE_FILE, "r") as f:
+                INSTALLATION_STATE = json.load(f)
+                LOGGER.debug(f"Loaded installation state from {STATE_FILE}")
+        except Exception as e:
+            LOGGER.warning(f"Could not load state file: {e}")
+            INSTALLATION_STATE = {"installations": [], "version": "1.0"}
+    else:
+        INSTALLATION_STATE = {"installations": [], "version": "1.0"}
+    return INSTALLATION_STATE
+
+
+def save_installation_state() -> None:
+    """Save current installation state to file"""
+    if not DRY_RUN:
+        try:
+            with open(STATE_FILE, "w") as f:
+                json.dump(INSTALLATION_STATE, f, indent=2)
+                LOGGER.debug(f"Saved installation state to {STATE_FILE}")
+        except Exception as e:
+            LOGGER.error(f"Could not save state file: {e}")
+
+
+def add_installation_record(record: InstallationRecord) -> None:
+    """Add an installation record to the state"""
+    record_dict = {
+        "name": record.name,
+        "category": record.category.value,
+        "method": record.method,
+        "success": record.success,
+        "timestamp": record.timestamp,
+        "packages": record.packages,
+    }
+    INSTALLATION_STATE["installations"].append(record_dict)
+    save_installation_state()
+
+
+def rollback_installation() -> None:
+    """Rollback the last installation session"""
+    if not INSTALLATION_STATE.get("installations"):
+        LOGGER.info("No installations to rollback")
+        return
+
+    # Get the latest session (installations from the same run)
+    latest_session = []
+    if INSTALLATION_STATE["installations"]:
+        latest_timestamp = INSTALLATION_STATE["installations"][-1]["timestamp"]
+        # Consider installations within 5 minutes as same session
+        session_window = 300  # 5 minutes
+
+        for install in reversed(INSTALLATION_STATE["installations"]):
+            if latest_timestamp - install["timestamp"] <= session_window:
+                latest_session.append(install)
+            else:
+                break
+
+    if not latest_session:
+        LOGGER.info("No recent installations to rollback")
+        return
+
+    LOGGER.info(f"Rolling back {len(latest_session)} installations...")
+    rollback_success = True
+
+    for install in latest_session:
+        if install["success"] and install["packages"]:
+            LOGGER.info(f"Rolling back {install['name']}")
+            if install["method"] == "apt":
+                ret = run_command("apt", "remove", "-y", *install["packages"])
+                if ret != 0:
+                    LOGGER.error(f"Failed to rollback {install['name']}")
+                    rollback_success = False
+            elif install["method"] == "snap":
+                for pkg in install["packages"]:
+                    ret = run_command("snap", "remove", pkg)
+                    if ret != 0:
+                        LOGGER.error(f"Failed to rollback snap package {pkg}")
+                        rollback_success = False
+            # Custom installations would need specific rollback logic
+
+    if rollback_success:
+        # Remove rolled back installations from state
+        INSTALLATION_STATE["installations"] = [
+            install
+            for install in INSTALLATION_STATE["installations"]
+            if install not in latest_session
+        ]
+        save_installation_state()
+        LOGGER.info("Rollback completed successfully")
+    else:
+        LOGGER.error("Rollback completed with some errors")
+
+
+def is_already_installed(software_name: str) -> bool:
+    """Check if software was already installed in a previous run"""
+    for install in INSTALLATION_STATE.get("installations", []):
+        if install["name"] == software_name and install["success"]:
+            LOGGER.debug(f"{software_name} already installed in previous run")
+            return True
+    return False
+
+
+def interactive_software_selection(categories: list) -> dict:
+    """Allow user to interactively select software to install"""
+    selection = {}
+
+    print("\n" + "=" * 60)
+    print("INTERACTIVE SOFTWARE SELECTION")
+    print("=" * 60)
+
+    for category_name in categories:
+        try:
+            category = SoftwareCategory(category_name)
+            software_list = SOFTWARE_CATALOG[category]
+
+            print(f"\n📁 {category.value.upper()} SOFTWARE:")
+            print("-" * 40)
+
+            for software_name, info in software_list.items():
+                if is_already_installed(software_name):
+                    print(
+                        f"  ✅ {software_name} - {info['description']} (already installed)"
+                    )
+                    selection[software_name] = False  # Skip already installed
+                    continue
+
+                while True:
+                    response = (
+                        input(
+                            f"  Install {software_name} - {info['description']}? [Y/n/q]: "
+                        )
+                        .strip()
+                        .lower()
+                    )
+                    if response in ["", "y", "yes"]:
+                        selection[software_name] = True
+                        break
+                    elif response in ["n", "no"]:
+                        selection[software_name] = False
+                        break
+                    elif response in ["q", "quit"]:
+                        print("Exiting...")
+                        sys.exit(0)
+                    else:
+                        print("  Please enter Y (yes), n (no), or q (quit)")
+
+        except ValueError:
+            LOGGER.error(f"Unknown category: {category_name}")
+
+    return selection
+
+
+def snap_install(*packages: str) -> int:
+    """Install packages using snap"""
+    if len(packages) == 0:
+        LOGGER.error("No packages provided to snap install")
+        return -1
+
+    LOGGER.debug(f"Installing via snap: {', '.join(packages)}")
+    success_count = 0
+
+    for package in packages:
+        ret = run_command("snap", "install", package)
+        if ret == 0:
+            success_count += 1
+        else:
+            LOGGER.error(f"Failed to install snap package: {package}")
+
+    return 0 if success_count == len(packages) else 1
+
+
+def install_custom_software(software_name: str) -> int:
+    """Handle custom software installations"""
+    if software_name == "uv":
+        return install_uv_new()
+    elif software_name == "poetry":
+        return install_poetry()
+    else:
+        LOGGER.error(f"Unknown custom software: {software_name}")
+        return 1
+
+
+def install_uv_new() -> int:
+    """Install uv with better error handling"""
+    if cmd_exists("uv"):
+        LOGGER.debug("uv already available")
+        return 0
+
+    LOGGER.debug("Installing uv from https://astral.sh/uv/install.sh")
+
+    # Try curl first
+    if cmd_exists("curl"):
+        ret = run_command("curl", "-LsSf", "https://astral.sh/uv/install.sh", "|", "sh")
+        if ret == 0:
+            LOGGER.debug("uv installation completed via curl")
+            return 0
+
+    # Try wget as fallback
+    if cmd_exists("wget"):
+        ret = run_command("wget", "-qO-", "https://astral.sh/uv/install.sh", "|", "sh")
+        if ret == 0:
+            LOGGER.debug("uv installation completed via wget")
+            return 0
+
+    LOGGER.error("Failed to install uv - neither curl nor wget available")
+    return 1
+
+
+def install_poetry() -> int:
+    """Install Poetry using the official installer"""
+    if cmd_exists("poetry"):
+        LOGGER.debug("poetry already available")
+        return 0
+
+    LOGGER.debug("Installing Poetry from get-poetry.py")
+
+    if cmd_exists("curl"):
+        ret = run_command(
+            "curl", "-sSL", "https://install.python-poetry.org", "|", "python3", "-"
+        )
+        if ret == 0:
+            LOGGER.debug("Poetry installation completed")
+            return 0
+
+    LOGGER.error("Failed to install Poetry")
+    return 1
+
+
+def install_software_by_category(
+    categories: list,
+    exclude_list: Optional[list] = None,
+    interactive_selection: Optional[dict] = None,
+) -> bool:
+    """Install software from specified categories"""
+    if exclude_list is None:
+        exclude_list = []
+
+    overall_success = True
+
+    for category_name in categories:
+        try:
+            category = SoftwareCategory(category_name)
+            software_list = SOFTWARE_CATALOG[category]
+
+            LOGGER.info(f"📁 Installing {category.value} software...")
+
+            for software_name, info in software_list.items():
+                # Skip if excluded or user deselected in interactive mode
+                if software_name in exclude_list:
+                    LOGGER.debug(f"Skipping excluded software: {software_name}")
+                    continue
+
+                if interactive_selection and not interactive_selection.get(
+                    software_name, True
+                ):
+                    LOGGER.debug(f"Skipping deselected software: {software_name}")
+                    continue
+
+                # Skip if already installed in previous run
+                if is_already_installed(software_name):
+                    LOGGER.info(f"✅ {software_name} already installed")
+                    continue
+
+                LOGGER.info(f"Installing {software_name}...")
+                start_time = time()
+
+                # Install based on method
+                success = False
+                packages_installed = []
+
+                if info["method"] == "apt":
+                    ret = apt_install(*info["packages"])
+                    success = ret == 0
+                    packages_installed = info["packages"] if success else []
+
+                elif info["method"] == "snap":
+                    ret = snap_install(*info["packages"])
+                    success = ret == 0
+                    packages_installed = info["packages"] if success else []
+
+                elif info["method"] == "custom":
+                    ret = install_custom_software(software_name)
+                    success = ret == 0
+                    packages_installed = [software_name] if success else []
+
+                # Record the installation attempt
+                record = InstallationRecord(
+                    name=software_name,
+                    category=category,
+                    method=info["method"],
+                    success=success,
+                    timestamp=start_time,
+                    packages=packages_installed,
+                )
+                add_installation_record(record)
+
+                if success:
+                    LOGGER.info(f"✅ {software_name} installed successfully")
+                else:
+                    LOGGER.error(f"❌ Failed to install {software_name}")
+                    overall_success = False
+
+        except ValueError:
+            LOGGER.error(f"Unknown category: {category_name}")
+            overall_success = False
+
+    return overall_success
+
+
+def main():
+    """Main function orchestrating the post-installation process"""
+    start = time()
+    parse_arguments()
+    setup_logging()
+
+    LOGGER.info("🚀 RATT Ubuntu Post-Install Script v1.0")
+    LOGGER.info(f"📝 Logging to: {LOG_PATH}")
+    LOGGER.info(f"💾 State file: {STATE_FILE}")
+    LOGGER.info(
+        f"⚙️  Running with VERBOSE={VERBOSE}, UPGRADE={UPGRADE}, DRY_RUN={DRY_RUN}"
+    )
+
+    # Load previous installation state
+    load_installation_state()
+
+    # Handle rollback request
+    if ROLLBACK:
+        LOGGER.info("🔄 Rolling back previous installation...")
+        rollback_installation()
+        return
+
+    # System updates
+    LOGGER.info("📦 Updating system packages...")
+    ret = apt_update()
+    if ret != 0:
+        LOGGER.error("Failed to update packages, continuing anyway...")
+
+    if UPGRADE:
+        LOGGER.info("⬆️  Upgrading system packages...")
+        ret = apt_upgrade()
+        if ret != 0:
+            LOGGER.error("Failed to upgrade packages, continuing anyway...")
+    else:
+        LOGGER.info("⏭️  Skipping system upgrade (--no-upgrade specified)")
+
+    # Get software selection
+    categories = []
+    exclude_list = []
+
+    # Parse categories from args (we need to re-access them)
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--categories", nargs="+", default=["essential"])
+    parser.add_argument("--exclude", nargs="+", default=[])
+    parser.add_argument("--interactive", action="store_true")
+    temp_args, _ = parser.parse_known_args()
+
+    categories = temp_args.categories
+    exclude_list = temp_args.exclude
+
+    LOGGER.info(f"📋 Selected categories: {', '.join(categories)}")
+    if exclude_list:
+        LOGGER.info(f"🚫 Excluded software: {', '.join(exclude_list)}")
+
+    # Interactive selection if requested
+    user_selection = None
+    if INTERACTIVE:
+        user_selection = interactive_software_selection(categories)
+        selected_count = sum(1 for selected in user_selection.values() if selected)
+        LOGGER.info(f"👤 User selected {selected_count} software packages")
+
+    # Install software
+    LOGGER.info("🔧 Starting software installation...")
+    success = install_software_by_category(categories, exclude_list, user_selection)
+
+    # Summary
+    duration = time() - start
+    if success:
+        LOGGER.info(f"✅ Post-install script completed successfully in {duration:.2f}s")
+    else:
+        LOGGER.warning(
+            f"⚠️  Post-install script completed with some errors in {duration:.2f}s"
+        )
+        LOGGER.info("💡 You can run with --rollback to undo the last installation")
+
+    LOGGER.info(
+        f"📊 Total installations tracked: {len(INSTALLATION_STATE.get('installations', []))}"
+    )
+    LOGGER.info("🎉 Ready for research work!")
+
+
+# Usage
+if __name__ == "__main__":
+    main()

--- a/ratt-software/ubuntu-24.04-lts-post-install.py
+++ b/ratt-software/ubuntu-24.04-lts-post-install.py
@@ -1,20 +1,30 @@
+from abc import ABC, abstractmethod
 import logging
 import argparse
+import os
+import datetime as dt
 from pathlib import Path
+import platform
+import shutil
 import subprocess
 import sys
 import json
 from time import time
-from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
+import re
+from typing import Dict, Callable
+
+# Meta-information
+TARGET_OS = "Ubuntu 24.04 LTS"
+VERSION = "0.1"
+LAST_MODIFIED = "19/07/2025"
+AUTHORS = [("Brian Welman", "github/kwazzi-jack")]  # Name, GitHub Username
 
 # Globals
 FOUND_COMMANDS = set()
 LOG_PATH: Path
 LOGGER: logging.Logger
-STATE_FILE: Path
-INSTALLATION_STATE: dict
 
 # Flags
 VERBOSE: bool = False
@@ -23,248 +33,147 @@ DRY_RUN: bool = False
 INTERACTIVE: bool = False
 ROLLBACK: bool = False
 
+# Compile regex patterns once at module level for better performance
+MARKUP_REGEX = re.compile(r"`([^`]+)`|\[(\w+)\](.*?)\[/\2\]")
+ANSI_ESCAPE_REGEX = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
-class SoftwareCategory(Enum):
-    """Categories of software that can be installed"""
-
-    ESSENTIAL = "essential"  # Basic system tools
-    DEVELOPMENT = "development"  # Programming tools
-    PYTHON = "python"  # Python ecosystem
-    RESEARCH = "research"  # Research-specific tools
-    MULTIMEDIA = "multimedia"  # Audio/video tools
-    PRODUCTIVITY = "productivity"  # General productivity tools
-
-
-@dataclass
-class InstallationRecord:
-    """Record of an installation attempt"""
-
-    name: str
-    category: SoftwareCategory
-    method: str  # apt, snap, curl, etc.
-    success: bool
-    timestamp: float
-    packages: list  # actual packages installed
-
-
-# Software catalog - easy to extend for your research group
-SOFTWARE_CATALOG = {
-    SoftwareCategory.ESSENTIAL: {
-        "curl": {
-            "packages": ["curl"],
-            "method": "apt",
-            "description": "Data transfer tool",
-        },
-        "wget": {
-            "packages": ["wget"],
-            "method": "apt",
-            "description": "Web downloader",
-        },
-        "git": {
-            "packages": ["git"],
-            "method": "apt",
-            "description": "Version control system",
-        },
-        "vim": {"packages": ["vim"], "method": "apt", "description": "Text editor"},
-        "htop": {
-            "packages": ["htop"],
-            "method": "apt",
-            "description": "System monitor",
-        },
-        "tree": {
-            "packages": ["tree"],
-            "method": "apt",
-            "description": "Directory tree viewer",
-        },
-        "zip": {
-            "packages": ["zip", "unzip"],
-            "method": "apt",
-            "description": "Archive utilities",
-        },
-    },
-    SoftwareCategory.DEVELOPMENT: {
-        "build-essential": {
-            "packages": ["build-essential"],
-            "method": "apt",
-            "description": "Compilation tools",
-        },
-        "cmake": {
-            "packages": ["cmake"],
-            "method": "apt",
-            "description": "Build system",
-        },
-        "nodejs": {
-            "packages": ["nodejs", "npm"],
-            "method": "apt",
-            "description": "Node.js runtime",
-        },
-        "docker": {
-            "packages": ["docker.io"],
-            "method": "apt",
-            "description": "Container platform",
-        },
-        "code": {
-            "packages": ["code"],
-            "method": "snap",
-            "description": "VS Code editor",
-        },
-    },
-    SoftwareCategory.PYTHON: {
-        "python3-dev": {
-            "packages": ["python3-dev", "python3-pip"],
-            "method": "apt",
-            "description": "Python development",
-        },
-        "uv": {
-            "packages": [],
-            "method": "custom",
-            "description": "Fast Python package manager",
-        },
-        "poetry": {
-            "packages": [],
-            "method": "custom",
-            "description": "Python dependency management",
-        },
-        "pipx": {
-            "packages": ["pipx"],
-            "method": "apt",
-            "description": "Install Python apps in isolation",
-        },
-    },
-    SoftwareCategory.RESEARCH: {
-        "r-base": {
-            "packages": ["r-base"],
-            "method": "apt",
-            "description": "R statistical computing",
-        },
-        "texlive": {
-            "packages": ["texlive-latex-base"],
-            "method": "apt",
-            "description": "LaTeX document system",
-        },
-        "pandoc": {
-            "packages": ["pandoc"],
-            "method": "apt",
-            "description": "Document converter",
-        },
-    },
-    SoftwareCategory.MULTIMEDIA: {
-        "ffmpeg": {
-            "packages": ["ffmpeg"],
-            "method": "apt",
-            "description": "Multimedia framework",
-        },
-        "imagemagick": {
-            "packages": ["imagemagick"],
-            "method": "apt",
-            "description": "Image manipulation",
-        },
-        "vlc": {"packages": ["vlc"], "method": "snap", "description": "Media player"},
-    },
-    SoftwareCategory.PRODUCTIVITY: {
-        "firefox": {
-            "packages": ["firefox"],
-            "method": "snap",
-            "description": "Web browser",
-        },
-        "libreoffice": {
-            "packages": ["libreoffice"],
-            "method": "snap",
-            "description": "Office suite",
-        },
-        "thunderbird": {
-            "packages": ["thunderbird"],
-            "method": "snap",
-            "description": "Email client",
-        },
-    },
+# Pre-built formatter lookup table with lambdas (compiled once at import)
+FORMATTERS: Dict[str, Callable[[str], str]] = {
+    "bold": lambda text: f"\033[1m{text}\033[0m",
+    "italics": lambda text: f"\033[3m{text}\033[0m",
+    "underline": lambda text: f"\033[4m{text}\033[0m",
+    "red": lambda text: f"\033[31m{text}\033[0m",
+    "green": lambda text: f"\033[32m{text}\033[0m",
+    "blue": lambda text: f"\033[34m{text}\033[0m",
+    "yellow": lambda text: f"\033[33m{text}\033[0m",
+    "orange": lambda text: f"\033[38;5;214m{text}\033[0m",
+    "gray": lambda text: f"\033[90m{text}\033[0m",
+    "white": lambda text: f"\033[37m{text}\033[0m",
 }
 
 
-def parse_arguments():
-    global VERBOSE, UPGRADE, DRY_RUN, LOG_PATH, INTERACTIVE, ROLLBACK, STATE_FILE
-    parser = argparse.ArgumentParser(
-        description="Post-installation script for setting up research group software",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  %(prog)s                                    # Install essential software only
-  %(prog)s --categories essential development # Install specific categories
-  %(prog)s --interactive                      # Interactive selection
-  %(prog)s --dry-run --verbose               # Preview what would be installed
-  %(prog)s --rollback                        # Rollback last installation
-        """,
-    )
-    parser.add_argument(
-        "-m", "--minimal", action="store_true", help="Minimal installation used (Cannot run with -f)."
-    )
-    parser.add_argument(
-        "-f", "--full", action="store_true", help="Full installation used (Cannot run with -m)."
-    )
-    parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Enable verbose logging"
-    )
-    parser.add_argument(
-        "--no-upgrade", action="store_true", help="Skip apt upgrade step"
-    )
-    parser.add_argument(
-        "-d",
-        "--dry-run",
-        action="store_true",
-        help="Preview commands without executing",
-    )
-    parser.add_argument(
-        "-i",
-        "--interactive",
-        action="store_true",
-        help="Interactive software selection",
-    )
-    parser.add_argument(
-        "--rollback", action="store_true", help="Rollback previous installation"
-    )
-    parser.add_argument(
-        "--categories",
-        nargs="+",
-        choices=[cat.value for cat in SoftwareCategory],
-        default=["essential"],
-        help="Software categories to install (default: essential)",
-    )
-    parser.add_argument(
-        "--exclude",
-        nargs="+",
-        default=[],
-        help="Software names to exclude from installation",
-    )
-    parser.add_argument(
-        "--log-file",
-        default="post-install.log",
-        help="Specify log file path (default: post-install.log)",
-    )
-    parser.add_argument(
-        "--state-file",
-        default="post-install-state.json",
-        help="State file for tracking installations (default: post-install-state.json)",
-    )
+def get_terminal_width() -> int:
+    try:
+        width = shutil.get_terminal_size().columns
+        return width if width > 60 else 60
+    except OSError:
+        return 80  # fallback width
 
-    args = parser.parse_args()
-    VERBOSE = args.verbose
-    UPGRADE = not args.no_upgrade
-    DRY_RUN = args.dry_run
-    INTERACTIVE = args.interactive
-    ROLLBACK = args.rollback
-    LOG_PATH = Path(args.log_file)
-    STATE_FILE = Path(args.state_file)
+
+def strip_ansi(text: str) -> str:
+    """Remove all ANSI escape sequences from text"""
+    return ANSI_ESCAPE_REGEX.sub("", text)
+
+
+def timestamp() -> str:
+    now = dt.datetime.now(dt.timezone.utc).astimezone()
+    utc_offset = now.strftime("%z")
+    formatted_time = now.strftime("%d/%m/%Y-%H:%M:%S")
+    return FORMATTERS["gray"](f"[{formatted_time}{utc_offset}]")
+
+
+def line():
+    print(FORMATTERS["gray"]("=" * get_terminal_width()))
+
+
+def info(message: str) -> None:
+    """Print info message with formatting and log clean version"""
+    print(f"{timestamp()} {message}")
+    LOGGER.info(message)
+
+
+def debug(message: str) -> None:
+    """Print debug message with formatting and log clean version"""
+    if VERBOSE:
+        formatted_msg = FORMATTERS["italics"](FORMATTERS["blue"](message))
+        print(f"{timestamp()} {formatted_msg}")
+    LOGGER.debug(message)
+
+
+def warn(message: str) -> None:
+    """Print warning message with formatting and log clean version"""
+    formatted_msg = FORMATTERS["bold"](FORMATTERS["yellow"](message))
+    print(f"{timestamp()} {formatted_msg}")
+    LOGGER.warning(message)
+
+
+def error(message: str) -> None:
+    """Print error message with formatting and log clean version"""
+    formatted_msg = FORMATTERS["bold"](FORMATTERS["red"](message))
+    print(f"{timestamp()} {formatted_msg}")
+    LOGGER.error(message)
+
+
+def success(message: str) -> None:
+    """Print success message with formatting and log clean version"""
+    formatted_msg = FORMATTERS["italics"](FORMATTERS["green"](message))
+    print(f"{timestamp()} {formatted_msg}")
+    LOGGER.info(message)
+
+
+def show_legend():
+    print(
+        "Legend:",
+        ",".join(
+            [
+                "INFO=White",
+                FORMATTERS["bold"](FORMATTERS["yellow"]("WARNING=Yellow")),
+                FORMATTERS["bold"](FORMATTERS["red"]("ERROR=Red")),
+                FORMATTERS["italics"](FORMATTERS["blue"]("DEBUG=Blue")),
+            ]
+        ),
+    )
+    line()
+    print()
+
+
+def show_header():
+    """Prints a formatted header with script information."""
+    print()
+    title = FORMATTERS["bold"](
+        FORMATTERS["green"](f"RATT {TARGET_OS} Post-Install Script v{VERSION}")
+    )
+    line()
+    print(title)
+    line()
+
+    # Meta information
+    print(f"Last modified: {FORMATTERS['blue'](LAST_MODIFIED)}")
+    print(
+        f"\nReport issues to:\n{FORMATTERS['blue'](FORMATTERS['underline']('https://github.com/ratt-ru/baby-ratts/issues'))}\n"
+    )
+    print("Author(s):")
+    for name, username in AUTHORS:
+        print(FORMATTERS["blue"](f"- {name} ({username})"))
+
+    # Warnings and disclaimers
+    print()
+    print(
+        FORMATTERS["bold"](
+            FORMATTERS["yellow"](
+                "Caution:\n"
+                "- It is strongly recommended to use\n"
+                "  `--dry-run` to review changes first.\n\n"
+                "- This script is provided as-is. Use \n"
+                "  at your own risk.\n"
+            )
+        )
+    )
+    line()
 
 
 def setup_logging():
     """Configure logging based on verbose flag"""
-    global LOGGER
+    global LOGGER, LOG_PATH
+    now = dt.datetime.now().strftime("%d_%m_%Y-%H_%M_%S")
+    LOG_PATH = Path.home() / ".logs" / f"post-install-{now}.log"
+    log_dir = LOG_PATH.parent
+    log_dir.mkdir(exist_ok=True)
     level = logging.DEBUG if VERBOSE else logging.INFO
     logging.basicConfig(
         level=level,
-        format="%(asctime)s - %(levelname)-5s - %(message)s",
+        format="%(asctime)s - %(levelname)s - %(message)s",
         handlers=[
-            logging.StreamHandler(sys.stdout),
             logging.FileHandler(LOG_PATH),
         ],
     )
@@ -272,490 +181,719 @@ def setup_logging():
 
 
 def safely_shutdown():
-    LOGGER.info("Safely shutting down")
+    """Safely shutdown the application"""
+    info("Safely shutting down")
     sys.exit(1)
 
 
-def cmd_exists(cmd: str) -> bool:
+def command_exists(cmd: str) -> bool:
+    """Check whether a command is present on the system using
+    the GNU `which` command. If `which` is missing, then probably
+    best to reinstall your operating system.
+
+    Args:
+        cmd (str): System command to check for.
+
+    Returns:
+        bool: Whether the command exists on the system or not.
+
+    Examples:
+    >>> command_exists("python3")
+    True
+    >>> command_exists("nonexistent_command")
+    False
+    """
+    # Check if previously checked
     if cmd in FOUND_COMMANDS:
         LOGGER.debug("Executable found. Previously checked")
         return True
     LOGGER.debug(f"Checking if new command {cmd} installed")
+    # If dry-run, assume it is present
     if DRY_RUN and cmd not in FOUND_COMMANDS:
         FOUND_COMMANDS.add(cmd)
         LOGGER.debug("Executable found. Adding to checked (DRY RUN)")
         return True
     try:
+        # Use `which` command to see if exe present
         result = subprocess.run(
             ["which", cmd], check=True, capture_output=True, text=True
         )
         if result.returncode == 0:
+            # Successfully found
             FOUND_COMMANDS.add(cmd)
             LOGGER.debug("Executable found. Adding to checked")
             return True
     except Exception:
+        # Any error is assumed to be failure
         pass
+    # Failed to find executable
     LOGGER.debug("Executable not found")
     return False
 
 
-def run_command(*cmd: str) -> int:
-    if not cmd_exists(cmd[0]):
-        LOGGER.debug(f"Command {cmd[0]} not found. Consider installing")
-        return -1
-    LOGGER.debug(f"Running: {' '.join(cmd)}")
-    if DRY_RUN:
-        FOUND_COMMANDS.add(cmd)
-        LOGGER.debug(f"Completed [DRY-RUN]: {cmd[0]}")
-        return 0
-    try:
-        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-        LOGGER.debug(f"Completed [{result.returncode}]: {cmd[0]}")
-        return result.returncode
-    except subprocess.CalledProcessError as error:
-        LOGGER.error(f"Failed: {' '.join(cmd)}")
-        LOGGER.error(f"Error: {error}")
-        safely_shutdown()
-    return 0
+def confirm(text: str = "Confirm", default: str = "yes") -> bool:
+    """
+    Prompt the user for confirmation with yes, no, or cancel options.
 
+    Args:
+        text (str): The prompt text to display to the user.
+        default (str): The default response ("yes", "no", or "cancel").
 
-def apt_update() -> int:
-    ret = run_command("apt", "update", "-y")
-    if ret == -1:
-        LOGGER.error("Missing apt command")
-        return 1
-    elif ret != 0:
-        LOGGER.error("Failed to update apt package list")
-        return 1
-    else:
-        LOGGER.debug("Update completed")
-        return 0
+    Returns:
+        bool: True if the user confirms with "yes", False if "no".
 
+    Raises:
+        ValueError: If any of the input arguments are invalid.
 
-def apt_upgrade() -> int:
-    LOGGER.debug("Upgrading apt packages")
-    ret = run_command("apt", "upgrade", "-y")
-    if ret == -1:
-        LOGGER.error("Missing apt command")
-        return 1
-    elif ret != 0:
-        LOGGER.error("Failed to upgrade apt packages")
-        return 1
-    else:
-        LOGGER.debug("Upgrade completed")
-        return 0
+    Examples:
+        >>> confirm("Do you want to continue?")
+        Confirm [y/n/c] (default: yes): y
+        True
 
+        >>> confirm("Delete file?", default="no")
+        Delete file? [y/n/c] (default: no): n
+        False
+    """
+    # Validate input arguments
+    if not text or not isinstance(text, str):
+        raise ValueError("Prompt text must be a non-empty string")
 
-def apt_install(*progs: str) -> int:
-    if len(progs) == 0:
-        LOGGER.error("No programs provided to install")
-        return 1
-    LOGGER.debug(f"Installing via apt: {', '.join(progs)}")
-    ret = run_command("apt", "install", "-y", *progs)
-    if ret == -1:
-        LOGGER.error("Missing apt command")
-        return 1
-    elif ret != 0:
-        LOGGER.error("Failed to install programs")
-        return 1
-    else:
-        LOGGER.debug("Installation completed")
-        return 0
+    if default not in ["yes", "no", "cancel"]:
+        raise ValueError("Default value must be 'yes', 'no', or 'cancel'")
 
-
-def load_installation_state() -> dict:
-    """Load previous installation state from file"""
-    global INSTALLATION_STATE
-    if STATE_FILE.exists():
-        try:
-            with open(STATE_FILE, "r") as f:
-                INSTALLATION_STATE = json.load(f)
-                LOGGER.debug(f"Loaded installation state from {STATE_FILE}")
-        except Exception as e:
-            LOGGER.warning(f"Could not load state file: {e}")
-            INSTALLATION_STATE = {"installations": [], "version": "1.0"}
-    else:
-        INSTALLATION_STATE = {"installations": [], "version": "1.0"}
-    return INSTALLATION_STATE
-
-
-def save_installation_state() -> None:
-    """Save current installation state to file"""
-    if not DRY_RUN:
-        try:
-            with open(STATE_FILE, "w") as f:
-                json.dump(INSTALLATION_STATE, f, indent=2)
-                LOGGER.debug(f"Saved installation state to {STATE_FILE}")
-        except Exception as e:
-            LOGGER.error(f"Could not save state file: {e}")
-
-
-def add_installation_record(record: InstallationRecord) -> None:
-    """Add an installation record to the state"""
-    record_dict = {
-        "name": record.name,
-        "category": record.category.value,
-        "method": record.method,
-        "success": record.success,
-        "timestamp": record.timestamp,
-        "packages": record.packages,
-    }
-    INSTALLATION_STATE["installations"].append(record_dict)
-    save_installation_state()
-
-
-def rollback_installation() -> None:
-    """Rollback the last installation session"""
-    if not INSTALLATION_STATE.get("installations"):
-        LOGGER.info("No installations to rollback")
-        return
-
-    # Get the latest session (installations from the same run)
-    latest_session = []
-    if INSTALLATION_STATE["installations"]:
-        latest_timestamp = INSTALLATION_STATE["installations"][-1]["timestamp"]
-        # Consider installations within 5 minutes as same session
-        session_window = 300  # 5 minutes
-
-        for install in reversed(INSTALLATION_STATE["installations"]):
-            if latest_timestamp - install["timestamp"] <= session_window:
-                latest_session.append(install)
-            else:
-                break
-
-    if not latest_session:
-        LOGGER.info("No recent installations to rollback")
-        return
-
-    LOGGER.info(f"Rolling back {len(latest_session)} installations...")
-    rollback_success = True
-
-    for install in latest_session:
-        if install["success"] and install["packages"]:
-            LOGGER.info(f"Rolling back {install['name']}")
-            if install["method"] == "apt":
-                ret = run_command("apt", "remove", "-y", *install["packages"])
-                if ret != 0:
-                    LOGGER.error(f"Failed to rollback {install['name']}")
-                    rollback_success = False
-            elif install["method"] == "snap":
-                for pkg in install["packages"]:
-                    ret = run_command("snap", "remove", pkg)
-                    if ret != 0:
-                        LOGGER.error(f"Failed to rollback snap package {pkg}")
-                        rollback_success = False
-            # Custom installations would need specific rollback logic
-
-    if rollback_success:
-        # Remove rolled back installations from state
-        INSTALLATION_STATE["installations"] = [
-            install
-            for install in INSTALLATION_STATE["installations"]
-            if install not in latest_session
+    # Build the prompt message
+    choices = "/".join(
+        [
+            f"{FORMATTERS['underline']('y')}es",
+            f"{FORMATTERS['underline']('N')}o",
+            f"{FORMATTERS['underline']('C')}ancel",
         ]
-        save_installation_state()
-        LOGGER.info("Rollback completed successfully")
-    else:
-        LOGGER.error("Rollback completed with some errors")
+    )
+    prompt_text = f"{text} [{choices}] (default: {default}):"
+    prompt = f"{timestamp()} {prompt_text} "
 
+    while True:
+        response = input(prompt).strip().lower()
 
-def is_already_installed(software_name: str) -> bool:
-    """Check if software was already installed in a previous run"""
-    for install in INSTALLATION_STATE.get("installations", []):
-        if install["name"] == software_name and install["success"]:
-            LOGGER.debug(f"{software_name} already installed in previous run")
+        # Use default if no input provided
+        if not response:
+            response = default
+
+        # Handle single letter or whole word inputs
+        if response in ["y", "yes"]:
             return True
-    return False
+        elif response in ["n", "no"]:
+            return False
+        elif response in ["c", "cancel"]:
+            safely_shutdown()
 
-
-def interactive_software_selection(categories: list) -> dict:
-    """Allow user to interactively select software to install"""
-    selection = {}
-
-    print("\n" + "=" * 60)
-    print("INTERACTIVE SOFTWARE SELECTION")
-    print("=" * 60)
-
-    for category_name in categories:
-        try:
-            category = SoftwareCategory(category_name)
-            software_list = SOFTWARE_CATALOG[category]
-
-            print(f"\n📁 {category.value.upper()} SOFTWARE:")
-            print("-" * 40)
-
-            for software_name, info in software_list.items():
-                if is_already_installed(software_name):
-                    print(
-                        f"  ✅ {software_name} - {info['description']} (already installed)"
-                    )
-                    selection[software_name] = False  # Skip already installed
-                    continue
-
-                while True:
-                    response = (
-                        input(
-                            f"  Install {software_name} - {info['description']}? [Y/n/q]: "
-                        )
-                        .strip()
-                        .lower()
-                    )
-                    if response in ["", "y", "yes"]:
-                        selection[software_name] = True
-                        break
-                    elif response in ["n", "no"]:
-                        selection[software_name] = False
-                        break
-                    elif response in ["q", "quit"]:
-                        print("Exiting...")
-                        sys.exit(0)
-                    else:
-                        print("  Please enter Y (yes), n (no), or q (quit)")
-
-        except ValueError:
-            LOGGER.error(f"Unknown category: {category_name}")
-
-    return selection
-
-
-def snap_install(*packages: str) -> int:
-    """Install packages using snap"""
-    if len(packages) == 0:
-        LOGGER.error("No packages provided to snap install")
-        return -1
-
-    LOGGER.debug(f"Installing via snap: {', '.join(packages)}")
-    success_count = 0
-
-    for package in packages:
-        ret = run_command("snap", "install", package)
-        if ret == 0:
-            success_count += 1
-        else:
-            LOGGER.error(f"Failed to install snap package: {package}")
-
-    return 0 if success_count == len(packages) else 1
-
-
-def install_custom_software(software_name: str) -> int:
-    """Handle custom software installations"""
-    if software_name == "uv":
-        return install_uv_new()
-    elif software_name == "poetry":
-        return install_poetry()
-    else:
-        LOGGER.error(f"Unknown custom software: {software_name}")
-        return 1
-
-
-def install_uv_new() -> int:
-    """Install uv with better error handling"""
-    if cmd_exists("uv"):
-        LOGGER.debug("uv already available")
-        return 0
-
-    LOGGER.debug("Installing uv from https://astral.sh/uv/install.sh")
-
-    # Try curl first
-    if cmd_exists("curl"):
-        ret = run_command("curl", "-LsSf", "https://astral.sh/uv/install.sh", "|", "sh")
-        if ret == 0:
-            LOGGER.debug("uv installation completed via curl")
-            return 0
-
-    # Try wget as fallback
-    if cmd_exists("wget"):
-        ret = run_command("wget", "-qO-", "https://astral.sh/uv/install.sh", "|", "sh")
-        if ret == 0:
-            LOGGER.debug("uv installation completed via wget")
-            return 0
-
-    LOGGER.error("Failed to install uv - neither curl nor wget available")
-    return 1
-
-
-def install_poetry() -> int:
-    """Install Poetry using the official installer"""
-    if cmd_exists("poetry"):
-        LOGGER.debug("poetry already available")
-        return 0
-
-    LOGGER.debug("Installing Poetry from get-poetry.py")
-
-    if cmd_exists("curl"):
-        ret = run_command(
-            "curl", "-sSL", "https://install.python-poetry.org", "|", "python3", "-"
+        # Invalid input
+        error(
+            "Invalid response. Please choose '', 'y/Y/yes/Yes', 'n/N/no/No', or 'c/C/cancel/Cancel'."
         )
-        if ret == 0:
-            LOGGER.debug("Poetry installation completed")
-            return 0
-
-    LOGGER.error("Failed to install Poetry")
-    return 1
 
 
-def install_software_by_category(
-    categories: list,
-    exclude_list: Optional[list] = None,
-    interactive_selection: Optional[dict] = None,
-) -> bool:
-    """Install software from specified categories"""
-    if exclude_list is None:
-        exclude_list = []
+class InstallMode(Enum):
+    STANDARD = "standard"
+    MINIMAL = "minimal"
+    FULL = "full"
+    CUSTOM = "custom"
 
-    overall_success = True
 
-    for category_name in categories:
+def arguments():
+    """Parse command line arguments and update global flags"""
+    global VERBOSE, UPGRADE, DRY_RUN, INTERACTIVE, ROLLBACK
+
+    parser = argparse.ArgumentParser(
+        description=f"RATT {TARGET_OS} Post-Install Script v{VERSION}",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+Examples:
+  %(prog)s --dry-run --verbose standard    # Test standard install with verbose output
+  %(prog)s --no-upgrade full               # Full install without package upgrades
+  %(prog)s custom                          # Interactive custom installation
+
+Report issues: https://github.com/ratt-ru/baby-ratts/issues
+Authors: {', '.join([f'{name} ({username})' for name, username in AUTHORS])}
+        """,
+    )
+
+    # Operational flags
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show verbose information during installation",
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run installation script without installing anything to verify everything works",
+    )
+
+    parser.add_argument(
+        "--no-upgrade",
+        dest="upgrade",
+        action="store_false",
+        default=UPGRADE,
+        help="Perform various package upgrades if available (default: %(default)s)",
+    )
+
+    parser.add_argument(
+        "mode",
+        choices=[mode.value for mode in InstallMode],
+        default=InstallMode.STANDARD.value,
+        help="Installation mode: standard (default), minimal, full, or custom",
+    )
+
+    # Parse arguments
+    args = parser.parse_args()
+
+    # Update global flags
+    VERBOSE = args.verbose
+    UPGRADE = args.upgrade
+    DRY_RUN = args.dry_run
+
+    # Return parsed mode for use in main logic
+    return InstallMode(args.mode)
+
+
+class Installer(ABC):
+    """Abstract base class for all installation methods."""
+
+    def __init__(
+        self,
+        name: str,
+        dependencies: Optional[list["SoftwarePackage"]] = None,
+        version: Optional[str] = None,
+    ):
+        self.name = name
+        self.dependencies = dependencies or []
+        self.version = version
+        self._installed: Optional[bool] = None
+
+    def is_installed(self) -> bool:
+        """Check if the software is installed. Caches the result."""
+        if self._installed is None:
+            debug(f"Checking if {self.name} is installed.")
+            self._installed = self._check_installed()
+            if self._installed:
+                debug(f"{self.name} is installed.")
+            else:
+                debug(f"{self.name} is NOT installed.")
+        return self._installed
+
+    @abstractmethod
+    def _check_installed(self) -> bool:
+        """Subclasses must implement this to check if the software is installed."""
+        raise NotImplementedError
+
+    def install(self) -> bool:
+        """Install all dependencies and then the software itself."""
+        debug(f"Starting installation for {self.name}")
+        if self.is_installed():
+            success(f"{self.name} is already installed.")
+            return True
+
+        # Install dependencies first
+        for dep in self.dependencies:
+            if not dep.is_installed():
+                info(f"Installing dependency for {self.name}: {dep.name}")
+                if not dep.install():
+                    error(f"Failed to install dependency: {dep.name}")
+                    return False
+
+        # Install the software
+        info(f"Installing {self.name}...")
+        if self._install_package():
+            self._installed = True
+            success(f"Successfully installed {self.name}")
+            return True
+        else:
+            error(f"Failed to install {self.name}")
+            return False
+
+    @abstractmethod
+    def _install_package(self) -> bool:
+        """Subclasses must implement the installation logic."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def uninstall(self) -> bool:
+        """Subclasses must implement the uninstallation logic."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_version(self) -> Optional[str]:
+        """Subclasses must implement logic to get the installed version."""
+        raise NotImplementedError
+
+    def run(self, *args: str, **kwargs: Any) -> bool:
+        """
+        Execute the command with given arguments.
+
+        Args:
+            *args: Command line arguments to pass to the command
+            **kwargs: Additional keyword arguments (passed to subprocess.run)
+
+        Returns:
+            bool: True if command executed successfully (returncode 0), False otherwise
+        """
+        if not self.is_installed():
+            error(f"Cannot run {self.name} as it is not installed.")
+            return False
+
+        cmd = [self.name] + list(args)
+        debug(f"Running command: {' '.join(cmd)}")
+
         try:
-            category = SoftwareCategory(category_name)
-            software_list = SOFTWARE_CATALOG[category]
+            subprocess_kwargs = {
+                "capture_output": kwargs.get("capture_output", False),
+                "text": kwargs.get("text", True),
+                "check": kwargs.get("check", False),
+                "cwd": kwargs.get("cwd"),
+                "env": kwargs.get("env"),
+                "timeout": kwargs.get("timeout"),
+            }
+            # Remove None values
+            subprocess_kwargs = {
+                k: v for k, v in subprocess_kwargs.items() if v is not None
+            }
 
-            LOGGER.info(f"📁 Installing {category.value} software...")
+            result = subprocess.run(cmd, **subprocess_kwargs)
+            return result.returncode == 0
+        except subprocess.TimeoutExpired:
+            error(f"Command '{self.name}' timed out.")
+            return False
+        except subprocess.CalledProcessError as e:
+            error(f"Command '{self.name}' failed with return code {e.returncode}.")
+            return False
+        except FileNotFoundError:
+            error(f"Command '{self.name}' not found.")
+            return False
+        except Exception as e:
+            error(f"An unexpected error occurred while running '{self.name}': {e}")
+            return False
 
-            for software_name, info in software_list.items():
-                # Skip if excluded or user deselected in interactive mode
-                if software_name in exclude_list:
-                    LOGGER.debug(f"Skipping excluded software: {software_name}")
-                    continue
 
-                if interactive_selection and not interactive_selection.get(
-                    software_name, True
-                ):
-                    LOGGER.debug(f"Skipping deselected software: {software_name}")
-                    continue
+class SoftwarePackage:
+    """Represents a piece of software that can be installed by one or more methods."""
 
-                # Skip if already installed in previous run
-                if is_already_installed(software_name):
-                    LOGGER.info(f"✅ {software_name} already installed")
-                    continue
+    def __init__(self, name: str, installers: list[Installer]):
+        if not installers:
+            raise ValueError("A SoftwarePackage must have at least one installer.")
+        self.name = name
+        self.installers = installers
+        self._installed_by: Optional[Installer] = None
 
-                LOGGER.info(f"Installing {software_name}...")
-                start_time = time()
+    def is_installed(self) -> bool:
+        """Check if the software is installed by any of the available installers."""
+        if self._installed_by:
+            return True
+        for installer in self.installers:
+            if installer.is_installed():
+                self._installed_by = installer
+                return True
+        return False
 
-                # Install based on method
-                success = False
-                packages_installed = []
+    def install(self) -> bool:
+        """Try to install the software using the available installers in order."""
+        if self.is_installed():
+            success(
+                f"{self.name} is already installed (via {self._installed_by.name})."
+            )
+            return True
 
-                if info["method"] == "apt":
-                    ret = apt_install(*info["packages"])
-                    success = ret == 0
-                    packages_installed = info["packages"] if success else []
-
-                elif info["method"] == "snap":
-                    ret = snap_install(*info["packages"])
-                    success = ret == 0
-                    packages_installed = info["packages"] if success else []
-
-                elif info["method"] == "custom":
-                    ret = install_custom_software(software_name)
-                    success = ret == 0
-                    packages_installed = [software_name] if success else []
-
-                # Record the installation attempt
-                record = InstallationRecord(
-                    name=software_name,
-                    category=category,
-                    method=info["method"],
-                    success=success,
-                    timestamp=start_time,
-                    packages=packages_installed,
-                )
-                add_installation_record(record)
-
-                if success:
-                    LOGGER.info(f"✅ {software_name} installed successfully")
+        for installer in self.installers:
+            info(
+                f"Attempting to install {self.name} using {installer.__class__.__name__}..."
+            )
+            try:
+                if installer.install():
+                    # Verify that the installation was successful with the method that should now work
+                    if installer.is_installed():
+                        self._installed_by = installer
+                        success(
+                            f"Successfully installed {self.name} using {installer.__class__.__name__}."
+                        )
+                        return True
+                    else:
+                        warn(
+                            f"Installer {installer.__class__.__name__} for {self.name} reported success, but verification failed."
+                        )
                 else:
-                    LOGGER.error(f"❌ Failed to install {software_name}")
-                    overall_success = False
+                    warn(
+                        f"Installation of {self.name} with {installer.__class__.__name__} failed."
+                    )
+            except Exception as e:
+                error(
+                    f"An exception occurred while trying to install {self.name} with {installer.__class__.__name__}: {e}"
+                )
+        error(f"All installation methods for {self.name} failed.")
+        return False
 
-        except ValueError:
-            LOGGER.error(f"Unknown category: {category_name}")
-            overall_success = False
 
-    return overall_success
+class AptPackage(Installer):
+    """Represents software installed via apt."""
+
+    def __init__(
+        self,
+        name: str,
+        dependencies: Optional[list[SoftwarePackage]] = None,
+        version: Optional[str] = None,
+    ):
+        super().__init__(name, dependencies, version)
+        if not command_exists("apt"):
+            msg = "apt command not found. This script requires apt to function."
+            error(msg)
+            raise RuntimeError(msg)
+
+    def _check_installed(self) -> bool:
+        # dpkg-query is a reliable way to check for installed packages
+        return (
+            subprocess.run(
+                ["dpkg-query", "-W", "-f='${Status}'", self.name],
+                capture_output=True,
+                text=True,
+            ).stdout.find("install ok installed")
+            != -1
+        )
+
+    def _install_package(self) -> bool:
+        cmd = ["sudo", "apt", "install", "-y", self.name]
+        if DRY_RUN:
+            info(f"[DRY RUN] Would run: {' '.join(cmd)}")
+            return True
+        return subprocess.run(cmd).returncode == 0
+
+    def uninstall(self) -> bool:
+        cmd = ["sudo", "apt", "remove", "-y", self.name]
+        if DRY_RUN:
+            info(f"[DRY RUN] Would run: {' '.join(cmd)}")
+            return True
+        return subprocess.run(cmd).returncode == 0
+
+    def get_version(self) -> Optional[str]:
+        if not self.is_installed():
+            return None
+        try:
+            # apt-cache policy can show the installed version
+            result = subprocess.run(
+                ["apt-cache", "policy", self.name],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            for line in result.stdout.splitlines():
+                if "Installed:" in line:
+                    version = line.split("Installed:")[1].strip()
+                    return version if version != "(none)" else None
+            return None
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return None
+
+
+class SnapPackage(Installer):
+    """Represents software installed via snap."""
+
+    def __init__(
+        self,
+        name: str,
+        dependencies: Optional[list[SoftwarePackage]] = None,
+        version: Optional[str] = None,
+    ):
+        super().__init__(name, dependencies, version)
+        if not command_exists("snap"):
+            info("Snap command not found, attempting to install snapd...")
+            snapd_installer = AptPackage("snapd")
+            if not snapd_installer.install():
+                msg = "Failed to install snapd, which is required for snap packages."
+                error(msg)
+                raise RuntimeError(msg)
+            success("snapd installed successfully.")
+
+    def _check_installed(self) -> bool:
+        # The `snap list` command shows installed snaps
+        result = subprocess.run(["snap", "list"], capture_output=True, text=True)
+        return self.name in result.stdout
+
+    def _install_package(self) -> bool:
+        cmd = ["sudo", "snap", "install", self.name]
+        if DRY_RUN:
+            info(f"[DRY RUN] Would run: {' '.join(cmd)}")
+            return True
+        return subprocess.run(cmd).returncode == 0
+
+    def uninstall(self) -> bool:
+        cmd = ["sudo", "snap", "remove", self.name]
+        if DRY_RUN:
+            info(f"[DRY RUN] Would run: {' '.join(cmd)}")
+            return True
+        return subprocess.run(cmd).returncode == 0
+
+    def get_version(self) -> Optional[str]:
+        if not self.is_installed():
+            return None
+        try:
+            result = subprocess.run(
+                ["snap", "list", self.name],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            lines = result.stdout.strip().splitlines()
+            if len(lines) > 1:
+                return lines[1].split()[1]  # Version is in the second column
+            return None
+        except (subprocess.CalledProcessError, FileNotFoundError, IndexError):
+            return None
+
+
+class PipPackage(Installer):
+    """Represents a Python package installed via pip."""
+
+    def __init__(
+        self,
+        name: str,
+        pip_executable: str = "pip3",
+        dependencies: Optional[list[SoftwarePackage]] = None,
+        version: Optional[str] = None,
+    ):
+        super().__init__(name, dependencies, version)
+        self.pip_executable = pip_executable
+        if not command_exists(self.pip_executable):
+            info(
+                f"{self.pip_executable} command not found, attempting to install python3-pip..."
+            )
+            pip_installer = AptPackage("python3-pip")
+            if not pip_installer.install():
+                msg = (
+                    "Failed to install python3-pip, which is required for pip packages."
+                )
+                error(msg)
+                raise RuntimeError(msg)
+            success("python3-pip installed successfully.")
+
+    def _check_installed(self) -> bool:
+        # `pip show` is a good way to check for a package
+        return (
+            subprocess.run(
+                [self.pip_executable, "show", self.name],
+                capture_output=True,
+                text=True,
+            ).returncode
+            == 0
+        )
+
+    def _install_package(self) -> bool:
+        target = self.name
+        if self.version:
+            target += f"=={self.version}"
+        cmd = [self.pip_executable, "install", target]
+        if DRY_RUN:
+            info(f"[DRY RUN] Would run: {' '.join(cmd)}")
+            return True
+        return subprocess.run(cmd).returncode == 0
+
+    def uninstall(self) -> bool:
+        cmd = [self.pip_executable, "uninstall", "-y", self.name]
+        if DRY_RUN:
+            info(f"[DRY RUN] Would run: {' '.join(cmd)}")
+            return True
+        return subprocess.run(cmd).returncode == 0
+
+    def get_version(self) -> Optional[str]:
+        if not self.is_installed():
+            return None
+        try:
+            result = subprocess.run(
+                [self.pip_executable, "show", self.name],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            for line in result.stdout.splitlines():
+                if line.startswith("Version:"):
+                    return line.split(":")[1].strip()
+            return None
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return None
+
+
+class ScriptInstaller(Installer):
+    """Represents software installed by executing a shell script, often fetched with curl or wget."""
+
+    def __init__(
+        self,
+        name: str,
+        install_script_url: str,
+        executable_path: str,
+        dependencies: Optional[list[SoftwarePackage]] = None,
+    ):
+        super().__init__(name, dependencies)
+        self.install_script_url = install_script_url
+        self.executable_path = Path(executable_path).expanduser()
+        if not command_exists("curl"):
+            info("curl command not found, attempting to install...")
+            curl_installer = AptPackage("curl")
+            if not curl_installer.install():
+                msg = "Failed to install curl, which is required for script-based installations."
+                error(msg)
+                raise RuntimeError(msg)
+            success("curl installed successfully.")
+
+    def _check_installed(self) -> bool:
+        # Check if the executable exists at the specified path
+        return self.executable_path.exists()
+
+    def _install_package(self) -> bool:
+        # This is a simplified example. Real-world scripts can be complex.
+        # Assumes a curl | bash pattern.
+        cmd = f"curl -sSL {self.install_script_url} | bash"
+        if DRY_RUN:
+            info(f"[DRY RUN] Would run: {cmd}")
+            return True
+        try:
+            # Using shell=True is necessary here but use with caution.
+            subprocess.run(cmd, shell=True, check=True)
+            return True
+        except subprocess.CalledProcessError as e:
+            error(f"Installation script for {self.name} failed: {e}")
+            return False
+
+    def uninstall(self) -> bool:
+        # Uninstallation for script-based installs is often not standardized.
+        # A common pattern is to just remove the executable.
+        if self.executable_path.exists():
+            info(f"Attempting to remove {self.executable_path}")
+            if DRY_RUN:
+                info(f"[DRY RUN] Would remove: {self.executable_path}")
+                return True
+            self.executable_path.unlink()
+            return True
+        warn(f"Could not find {self.executable_path} to uninstall.")
+        return False
+
+    def get_version(self) -> Optional[str]:
+        if not self.is_installed():
+            return None
+        # Version fetching depends heavily on the installed tool.
+        # Common patterns are --version or -v.
+        for flag in ["--version", "-v", "version"]:
+            try:
+                result = subprocess.run(
+                    [str(self.executable_path), flag],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                # This is a simple regex, might need adjustment for specific tools
+                match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
+                if match:
+                    return match.group(1)
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                continue
+        debug(f"Could not determine version for {self.name}")
+        return None
+
+
+def install_minimal(): ...
+
+
+def install_standard():
+    """Defines and executes the standard installation sequence."""
+    info("Starting standard installation process...")
+
+    # Define dependencies that might be shared
+    curl_dep = SoftwarePackage("curl", [AptPackage("curl")])
+    snapd_dep = SoftwarePackage("snapd", [AptPackage("snapd")])
+    pip_dep = SoftwarePackage("python3-pip", [AptPackage("python3-pip")])
+
+    # Define software to be installed
+    packages_to_install = [
+        SoftwarePackage("vim", [AptPackage("vim")]),
+        SoftwarePackage("git", [AptPackage("git")]),
+        SoftwarePackage(
+            "vscode",
+            [
+                SnapPackage("code", dependencies=[snapd_dep]),
+                # Could add an alternative to download .deb and install with apt
+            ],
+        ),
+        SoftwarePackage("uv", [PipPackage("uv", dependencies=[pip_dep])]),
+        SoftwarePackage(
+            "nvm",
+            [
+                ScriptInstaller(
+                    name="nvm",
+                    install_script_url="https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh",
+                    executable_path="~/.nvm/nvm.sh",
+                    dependencies=[curl_dep],
+                )
+            ],
+        ),
+    ]
+
+    # Install all packages
+    for pkg in packages_to_install:
+        if not pkg.install():
+            error(f"Stopping installation due to failure in installing {pkg.name}.")
+            safely_shutdown()
+
+    success("Standard installation completed successfully!")
+
+
+def install_full(): ...
+
+
+def install_custom(): ...
 
 
 def main():
-    """Main function orchestrating the post-installation process"""
-    start = time()
-    parse_arguments()
     setup_logging()
+    try:
+        # Show preamble
+        show_header()
+        show_legend()
 
-    LOGGER.info("🚀 RATT Ubuntu Post-Install Script v1.0")
-    LOGGER.info(f"📝 Logging to: {LOG_PATH}")
-    LOGGER.info(f"💾 State file: {STATE_FILE}")
-    LOGGER.info(
-        f"⚙️  Running with VERBOSE={VERBOSE}, UPGRADE={UPGRADE}, DRY_RUN={DRY_RUN}"
-    )
+        # Parse arguments and get installation mode
+        install_mode = arguments()
 
-    # Load previous installation state
-    load_installation_state()
+        # Display configuration values
+        info(f"Logging to: {str(LOG_PATH)}")
+        info(f"Script version: {VERSION}")
+        info(f"Target Operating System: {TARGET_OS}")
+        info(f"Flags: {VERBOSE=}, {UPGRADE=}, {DRY_RUN=}")
+        info(f"Install mode: {install_mode.value}")
 
-    # Handle rollback request
-    if ROLLBACK:
-        LOGGER.info("🔄 Rolling back previous installation...")
-        rollback_installation()
-        return
+        if not confirm(text="Would you like to start?"):
+            # Stop installation
+            safely_shutdown()
 
-    # System updates
-    LOGGER.info("📦 Updating system packages...")
-    ret = apt_update()
-    if ret != 0:
-        LOGGER.error("Failed to update packages, continuing anyway...")
-
-    if UPGRADE:
-        LOGGER.info("⬆️  Upgrading system packages...")
-        ret = apt_upgrade()
-        if ret != 0:
-            LOGGER.error("Failed to upgrade packages, continuing anyway...")
-    else:
-        LOGGER.info("⏭️  Skipping system upgrade (--no-upgrade specified)")
-
-    # Get software selection
-    categories = []
-    exclude_list = []
-
-    # Parse categories from args (we need to re-access them)
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--categories", nargs="+", default=["essential"])
-    parser.add_argument("--exclude", nargs="+", default=[])
-    parser.add_argument("--interactive", action="store_true")
-    temp_args, _ = parser.parse_known_args()
-
-    categories = temp_args.categories
-    exclude_list = temp_args.exclude
-
-    LOGGER.info(f"📋 Selected categories: {', '.join(categories)}")
-    if exclude_list:
-        LOGGER.info(f"🚫 Excluded software: {', '.join(exclude_list)}")
-
-    # Interactive selection if requested
-    user_selection = None
-    if INTERACTIVE:
-        user_selection = interactive_software_selection(categories)
-        selected_count = sum(1 for selected in user_selection.values() if selected)
-        LOGGER.info(f"👤 User selected {selected_count} software packages")
-
-    # Install software
-    LOGGER.info("🔧 Starting software installation...")
-    success = install_software_by_category(categories, exclude_list, user_selection)
-
-    # Summary
-    duration = time() - start
-    if success:
-        LOGGER.info(f"✅ Post-install script completed successfully in {duration:.2f}s")
-    else:
-        LOGGER.warning(
-            f"⚠️  Post-install script completed with some errors in {duration:.2f}s"
-        )
-        LOGGER.info("💡 You can run with --rollback to undo the last installation")
-
-    LOGGER.info(
-        f"📊 Total installations tracked: {len(INSTALLATION_STATE.get('installations', []))}"
-    )
-    LOGGER.info("🎉 Ready for research work!")
+        # Perfrom installation based on mode
+        match install_mode:
+            case InstallMode.STANDARD:
+                debug("Starting standard installation")
+                install_standard()
+                debug("Ending STANDARD installation")
+            case InstallMode.MINIMAL:
+                debug("Starting MINIMAL installation")
+                install_minimal()
+                debug("Ending MINIMAL installation")
+            case InstallMode.FULL:
+                debug("Starting FULL installation")
+                install_full()
+                debug("Ending FULL installation")
+            case InstallMode.CUSTOM:
+                debug("Starting CUSTOM installation")
+                install_custom()
+                debug("Ending CUSTOM installation")
+    except KeyboardInterrupt:
+        error("Installation interrupted by user")
+    except Exception as e:
+        error(f"Error during installation: {e}. Halting")
+    safely_shutdown()
 
 
 # Usage


### PR DESCRIPTION
Extending a script I am working on to allow for automated installation of RATT software following an *Ubuntu 24.04 LTS*. It should do the following:

- [ ] Pure python script to run with builtin binaries from above OS.
- [ ] Allow for both simple, complete and customised installations via several argument flags.
- [ ] Allow for roll-back or repeated installations.
- [ ] Be robust and tested in isolated environments.
- [ ] Generated quality-of-life configurations and settings, e.g. ssh, jupyter, etc.

If this works, we could avoid having to setup and rice our own Ubuntu image and should be independent of display system choices, e.g. Xubuntu, Kubuntu, etc.

Any suggestions and changes for the script would be helpful! Also, I proper typing and annotations with python :)